### PR TITLE
Emily mailer update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Gemfile.lock
 yarn.lock
 
 public/packs/*
+public/packs-test/*

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@
 Gemfile.lock
 yarn.lock
 
-/public/packs/
+public/packs/*

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 
 .env
 /node_modules
+
+Gemfile.lock
+yarn.lock
+
+/public/packs/

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,10 +26,29 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # Set up development mailer for local dev environment.
+  config.action_mailer.default_url_options = { :host => 'localhost:5000' }
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false
+
+  # Set mailer delivery method.
+  config.action_mailer.delivery_method = :smtp
+
+  # Enable dev environment mailer.
+  config.action_mailer.perform_deliveries = true
+
+  config.action_mailer.smtp_settings = {
+    address: "smtp.gmail.com",
+    port: 587,
+    domain: 'gmail.com',
+    authentication: 'plain',
+    enable_starttls_auto: true,
+    user_name: 'lunch.academy',
+    password: 'aF3787yXJzgs'
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -16,7 +16,7 @@ Devise.setup do |config|
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'Devise::Mailer'
-  ActionMailer::Base.default_url_options = { :host => 'localhost' }
+  ActionMailer::Base.default_url_options = { :host => 'localhost:5000' }
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -15,7 +15,8 @@ Devise.setup do |config|
   config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'Devise::Mailer'
+  ActionMailer::Base.default_url_options = { :host => 'localhost' }
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/public/packs-test/manifest.json
+++ b/public/packs-test/manifest.json
@@ -1,4 +1,0 @@
-{
-  "application.js": "/packs-test/application-9e6551123af98217431f.js",
-  "sandwiches.js": "/packs-test/sandwiches-1fa5daa393b264055f09.js"
-}

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,3 +1,0 @@
-{
-  "application.js": "/packs/application-e28e2bb5fc71476e4ca2.js"
-}

--- a/spec/features/02_visitor_sends_password_reset_email_spec.rb
+++ b/spec/features/02_visitor_sends_password_reset_email_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+class ResetPasswordTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:example)
+  end
+
+  test "reset user's password" do
+    # store old encrypted password
+    old_password = @user.encrypted_password
+
+    # check to ensure mailer sends reset password email
+    assert_difference('ActionMailer::Base.deliveries.count', 1) do
+      post user_password_path, user: {email: @user.email}
+      assert_redirected_to new_user_session_path
+    end
+
+    # Get the email, and get the reset password token from it
+    message = ActionMailer::Base.deliveries[0].to_s
+    rpt_index = message.index("reset_password_token")+"reset_password_token".length+1
+    reset_password_token = message[rpt_index...message.index("\"", rpt_index)]
+
+    # reload the user and ensure user.reset_password_token is present
+    # NOTE: user.reset_password_token and the token pulled from the email
+    # are DIFFERENT
+    @user.reload
+    assert_not_nil @user.reset_password_token
+
+    # Ensure that a bad token won't reset the password
+    put "/users/password", user: {
+      reset_password_token: "bad reset token",
+      password: "new-password",
+      password_confirmation: "new-password",
+    }
+
+    assert_match "error", response.body
+    assert_equal @user.encrypted_password, old_password
+
+    # Valid password update
+    put "/users/password", user: {
+      reset_password_token: reset_password_token,
+      password: "new-password",
+      password_confirmation: "new-password",
+    }
+
+    # After password update, signed in and redirected to root path
+    assert_redirected_to root_path
+
+    # Reload user and ensure that the password is updated.
+    @user.reload
+    assert_not_equal(@user.encrypted_password, old_password)
+  end
+
+end


### PR DESCRIPTION
Configures mailer to use lunch.academy@gmail.com to send password reset emails to users (with a hardcoded password for now).

Also updates .gitignore to ignore Gemfile.lock and yarn.lock since they've been giving us errors and we haven't pushed a change to master for that yet.